### PR TITLE
Personinfo debug

### DIFF
--- a/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
@@ -55,7 +55,7 @@ public class PersonopplysningerService {
         } catch (HentPersonhistorikkPersonIkkeFunnet hentPersonhistorikkPersonIkkeFunnet) {
             // Fant ikke personen returnerer tomt sett
             LOG.info("Prøver å hente historikk for person som ikke finnes i TPS");
-            return PersonhistorikkInfo.builder().medAktørId(aktørId.getId()).build();
+            throw new IllegalArgumentException(hentPersonhistorikkPersonIkkeFunnet);
         }
     }
 

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -8,4 +8,4 @@ no.nav.security.oidc:
 SECURITYTOKENSERVICE_URL: https://sts-q1.preprod.local/SecurityTokenServiceProvider/
 STS_REST_URL: https://security-token-service.nais.preprod.local
 AKTOERID_URL: https://app-q0.adeo.no/aktoerregister/api/v1
-PERSON_V3_URL: https://wasapp-q1.adeo.no/tpsws/ws/Person/v3
+PERSON_V3_URL: https://wasapp-q0.adeo.no/tpsws/ws/Person/v3

--- a/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerServiceTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerServiceTest.java
@@ -45,17 +45,12 @@ public class PersonopplysningerServiceTest {
         personopplysningerService = new PersonopplysningerService(this.personConsumer, new TpsOversetter(new TpsAdresseOversetter()));
     }
 
-    @Test
-    public void skalReturnereTomPersonhistorikkInfoVedUgyldigAktørId() throws Exception {
+    @Test(expected = IllegalArgumentException.class)
+    public void personhistorikkInfoSkalGiFeilVedUgyldigAktørId() throws Exception {
         when(personConsumer.hentPersonhistorikkResponse(any(HentPersonhistorikkRequest.class)))
                 .thenThrow(new HentPersonhistorikkPersonIkkeFunnet("Feil", any(PersonIkkeFunnet.class)));
 
         PersonhistorikkInfo response = personopplysningerService.hentHistorikkFor(new AktørId(AKTØR_ID), FOM, TOM);
-
-        assertThat(response.getAktørId()).isEqualTo(AKTØR_ID);
-        assertThat(response.getAdressehistorikk()).isNullOrEmpty();
-        assertThat(response.getPersonstatushistorikk()).isNullOrEmpty();
-        assertThat(response.getStatsborgerskaphistorikk()).isNullOrEmpty();
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
- AktørId henta fra q0 var ugyldig ved bruk av personV3 i q1 (bruker lå i begge miljø), så går mot personV3 i q0 i stedet.
- `/api/personopplysning/historikk` ga responskode 200 og tomt objekt ved ugyldig aktørId. Har endret så det kastes exception, i likhet med `/api/personopplysning/info`.