### PR TITLE
Bugfix: Workflow for prod

### DIFF
--- a/.github/tag.sh
+++ b/.github/tag.sh
@@ -38,6 +38,7 @@ new_minor=$current_minor
 
 if [ "$major" = true ]; then
     ((new_major++))
+    new_minor=0
 fi
 
 if [ "$minor" = true ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,15 +14,29 @@ jobs:
         run: |
           commit=$(git rev-parse --short HEAD)
           if ! [[ $(git branch -r --contains "$commit" | grep -E '(^|\s)origin/master$') ]]; then exit 1; fi
-      - name: Lag Docker tag for deploy
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Bygg med maven
+        run: mvn package --file pom.xml
+      - name: Lag Docker tag
         env:
           NAME: familie-ks-oppslag
         run: |
           echo "docker.pkg.github.com"/"$GITHUB_REPOSITORY"/"$NAME" > .docker_image
-          commit=$(git rev-parse --short HEAD)
-          tags_for_commit=$(docker images docker.pkg.github.com/navikt/familie-ks-oppslag/familie-ks-oppslag --format "{{.Tag}}" | grep "$commit")
-          echo "Liste av docker tags: $tags_for_commit"
-          echo "$tags_for_commit" | cut -c 1-18 > .docker_tag
+          echo "$(date "+%Y.%m.%d")-$(git rev-parse --short HEAD)" > .docker_tag
+      - name: Bygg Docker image
+        run: |
+          docker build -t $(cat .docker_image):$(cat .docker_tag) .
+      - name: Login to Github Package Registry
+        env:
+          DOCKER_USERNAME: x-access-token
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
+      - name: Push Docker image
+        run: "docker push $(cat .docker_image):$(cat .docker_tag)"
       - name: Deploy til dev-fss
         uses: navikt/deployment-cli/action@b60ef91
         env:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ For å kjøre opp appen lokalt kan en kjøre `DevLauncher` med Spring-profilen `
 Appen er da tilgjengelig under `localhost:8085`.
 
 Dersom man vil gå mot endepunkter som krever autentisering lokalt, kan man få et testtoken ved å gå mot `localhost:8085/local/cookie`. 
+
+
+## Produksjonssetting
+Hvis du skal deploye appen til prod, må du pushe en ny tag på master. Dette gjøres ved å kjøre tag-scriptet som ligger i `.github`-mappen. Da spesifiserer du om du vil bumpe major eller minor, scriptet vil da bumpe med 1 opp fra nyeste tag. 
+
+Eksempelvis: 
+
+Nyeste tag er `v0.5`.`./tag.sh -M` vil da pushe tagen `v1.0`, og `./tag.sh -m` vil pushe tagen `v0.6`.
+
+Når en ny tag pushes, trigges github action workflowen som heter Deploy-Prod. 


### PR DESCRIPTION
Hadde misforstått hvordan `docker images`- kommandoen fungerte. Det finnes dessverre ingen enkel måte å hente ut alle tags for et gitt docker image på. Derfor har jeg endret prod-workflowen slik at man bygger et nytt docker image som korresponderer til commiten man tagger/prodsetter. 