### PR TITLE
Forbedret logg og statuskode hvis aktørregisteret ikke finner fnr

### DIFF
--- a/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
@@ -100,7 +100,8 @@ public class PersonopplysningerService {
             status = HttpStatus.NOT_FOUND;
             feilmelding.add("message", hentPersonPersonIkkeFunnet.getMessage());
         } catch (NullPointerException npe) {
-            status = personIdentResponse.getStatusCode();
+            LOG.info("Fant ikke fødselsnummer for aktørId {} i aktørreg. Klarer ikke hente personinfo fra TPS", aktørId);
+            status = HttpStatus.NOT_FOUND;
             feilmelding.addAll("message", Optional.ofNullable(personIdentResponse.getHeaders().get("message"))
                     .orElse(List.of("aktørService::getPersonIdent returnerte null"))
             );

--- a/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerService.java
@@ -71,7 +71,8 @@ public class PersonopplysningerService {
             status = HttpStatus.NOT_FOUND;
             feilmelding.add("message", hentPersonhistorikkPersonIkkeFunnet.getMessage());
         } catch (NullPointerException npe) {
-            status = personIdentResponse.getStatusCode();
+            LOG.info("Fant ikke fødselsnummer for aktørId {} i aktørreg. Klarer ikke hente historikk fra TPS", aktørId);
+            status = HttpStatus.NOT_FOUND;
             feilmelding.addAll("message", Optional.ofNullable(personIdentResponse.getHeaders().get("message"))
                     .orElse(List.of("aktørService::getPersonIdent returnerte null"))
             );


### PR DESCRIPTION
Vi har gått over til å spørre TPS med fødselsnummer. Før vi spør TPS om info/historikk, bruker vi aktørregisteret til å veksle inn aktørId til fødselsnummer. Men hvis aktørregisteret ikke finner noe fnr for en gitt aktørid, returnerer den 200. Har derfor oppdatert PersonopplysningerServicen til å returnere 404 og logge dersom dette oppstår. Hvis ikke forstår ikke ks-sak at noe har gått galt i uthentingen fra TPS.