### PR TITLE
Oppslagstjeneste for å hente gsaksnummer for journalføring

### DIFF
--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostController.java
@@ -1,0 +1,53 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+import no.nav.security.oidc.api.ProtectedWithClaims;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpStatusCodeException;
+
+@RestController
+@ProtectedWithClaims(issuer = "intern")
+@RequestMapping("/api/journalpost")
+public class HentJournalpostController {
+    private static final Logger LOG = LoggerFactory.getLogger(HentJournalpostController.class);
+
+    @Autowired
+    private JournalpostService journalpostService;
+
+    @ExceptionHandler(JournalpostRestClientException.class)
+    public ResponseEntity<String> handleRestClientException(
+            JournalpostRestClientException ex) {
+        if (ex.getCause() instanceof HttpStatusCodeException){
+            HttpStatusCodeException cex = (HttpStatusCodeException) ex.getCause();
+            LOG.warn("Kunne ikke hente journalpost med id={} statuscode={} body={}", ex.getJournalpostId(), cex.getStatusCode(), cex.getResponseBodyAsString());
+            if(cex.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                return new ResponseEntity<>("Fant ikke journalpost med id=" + ex.getJournalpostId(), HttpStatus.NOT_FOUND);
+            }
+        } else {
+            LOG.warn("Feil ved henting av journalpostId={} klientfeilmelding={}", ex.getJournalpostId(), ex.getMessage(), ex);
+        }
+        return new ResponseEntity<>("Feil ved henting av journalpostId=" + ex.getJournalpostId(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public void handleRequestParserException(
+            RuntimeException ex) {
+        LOG.error("Feil ved henting av journalpostId", ex);
+    }
+
+
+    @GetMapping("/{journalpostId}/sak")
+    public ResponseEntity<String> hentSaksnummer(@PathVariable(name = "journalpostId") String journalpostId) {
+        String saksnummer = journalpostService.hentSaksnummer(journalpostId);
+        if (saksnummer == null) {
+            return new ResponseEntity<>("Sak mangler for journalpostId=" + journalpostId, HttpStatus.NOT_FOUND);
+        } else {
+            return new ResponseEntity<>(saksnummer, HttpStatus.OK);
+        }
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostRequestParserException.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostRequestParserException.java
@@ -1,0 +1,9 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+
+public class JournalpostRequestParserException extends RuntimeException {
+
+    public JournalpostRequestParserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostRestClientException.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostRestClientException.java
@@ -1,0 +1,16 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+
+public class JournalpostRestClientException extends RuntimeException {
+    private String journalpostId;
+
+
+    public JournalpostRestClientException(String message, Throwable cause, String journalpostId) {
+        super(message, cause);
+        this.journalpostId = journalpostId;
+    }
+
+    public String getJournalpostId() {
+        return journalpostId;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/JournalpostService.java
@@ -1,0 +1,22 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+import no.nav.familie.ks.oppslag.journalpost.internal.Journalpost;
+import no.nav.familie.ks.oppslag.journalpost.internal.SafKlient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JournalpostService {
+
+    @Autowired
+    private SafKlient safClient;
+
+
+    public String hentSaksnummer(String journalpostId) {
+        Journalpost journalpost =  safClient.hentJournalpost(journalpostId);
+        if (journalpost.getSak() != null && "GSAK".equals(journalpost.getSak().getArkivsaksystem())) {
+            return journalpost.getSak().getArkivsaksnummer();
+        }
+        return null;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/Journalpost.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/Journalpost.java
@@ -1,0 +1,23 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+public class Journalpost {
+
+    private String journalpostId;
+    private Sak sak;
+
+    public Journalpost() {
+    }
+
+    public Journalpost(String journalpostId, Sak sak) {
+        this.journalpostId = journalpostId;
+        this.sak = sak;
+    }
+
+    public String getJournalpostId() {
+        return journalpostId;
+    }
+
+    public Sak getSak() {
+        return sak;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostData.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostData.java
@@ -1,0 +1,9 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+public class SafJournalpostData {
+    private Journalpost journalpost;
+
+    public Journalpost getJournalpost() {
+        return journalpost;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostRequest.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostRequest.java
@@ -1,0 +1,10 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+class SafJournalpostRequest {
+    private final String query = "query Journalpost($journalpostId: String!) {journalpost(journalpostId: $journalpostId) {journalpostId sak {arkivsaksystem arkivsaksnummer datoOpprettet}}}";
+    private SafRequestVariable variables;
+
+    public SafJournalpostRequest(SafRequestVariable variables) {
+        this.variables = variables;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostResponse.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafJournalpostResponse.java
@@ -1,0 +1,12 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+class SafJournalpostResponse {
+    private SafJournalpostData data;
+
+    public SafJournalpostData getData() {
+        return data;
+    }
+
+    public SafJournalpostResponse() {
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafKlient.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafKlient.java
@@ -1,0 +1,101 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import no.nav.familie.ks.oppslag.felles.MDCOperations;
+import no.nav.familie.http.sts.StsRestClient;
+import no.nav.familie.ks.oppslag.journalpost.JournalpostRequestParserException;
+import no.nav.familie.ks.oppslag.journalpost.JournalpostRestClientException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.*;
+
+@Service
+public class SafKlient {
+    private static final String NAV_CONSUMER_ID = "Nav-Consumer-Id";
+    private static final String NAV_CALL_ID = "nav-callid";
+    private final Timer hentJournalpostResponstid = Metrics.timer("saf.journalpost.tid");
+    private final Counter hentJournalpostResponsSuccess = Metrics.counter("saf.journalpost.response", "status", "success");
+    private final Counter hentJournalpostResponsFailure = Metrics.counter("saf.journalpost.response", "status", "failure");
+
+    private RestTemplate restTemplate;
+    private StsRestClient stsRestClient;
+    private ObjectMapper objectMapper;
+    private String consumer;
+    private URI safUri;
+
+    public SafKlient(@Value("${SAF_URL}") String safUrl,
+                     @Value("${CREDENTIAL_USERNAME}") String consumer,
+                     @Autowired StsRestClient stsRestClient) {
+        this.stsRestClient = stsRestClient;
+        this.consumer = consumer;
+        this.objectMapper = new ObjectMapper();
+        objectMapper
+                .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        restTemplate = new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+        safUri = URI.create(safUrl);
+    }
+
+    public Journalpost hentJournalpost(String journalpostId) {
+        SafJournalpostRequest safJournalpostRequest = new SafJournalpostRequest(new SafRequestVariable(journalpostId));
+        String systembrukerToken = stsRestClient.getSystemOIDCToken();
+
+        String requestBody = convertRequestToJsonString(journalpostId, safJournalpostRequest);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(systembrukerToken);
+        headers.add(NAV_CALL_ID, MDCOperations.getCallId());
+        headers.add(NAV_CONSUMER_ID, consumer);
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+
+        long startTime = System.nanoTime();
+        try {
+            ResponseEntity<SafJournalpostResponse> response = this.restTemplate.exchange(
+                    safUri,
+                    HttpMethod.POST,
+                    request,
+                    SafJournalpostResponse.class);
+            hentJournalpostResponstid.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            hentJournalpostResponsSuccess.increment();
+            return Objects.requireNonNull(response.getBody()).getData().getJournalpost();
+        } catch (RestClientException e) {
+            hentJournalpostResponsFailure.increment();
+            throw new JournalpostRestClientException(e.getMessage(), e, journalpostId);
+        }
+    }
+
+    private String convertRequestToJsonString(String journalpostId, SafJournalpostRequest safJournalpostRequest) {
+        try {
+            return objectMapper
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(safJournalpostRequest);
+        } catch (JsonProcessingException e) {
+            hentJournalpostResponsFailure.increment();
+            throw new JournalpostRequestParserException("Parsing av request mot saf feilet for journalpostId=" + journalpostId);
+        }
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafRequestVariable.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/SafRequestVariable.java
@@ -1,0 +1,18 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+class SafRequestVariable {
+
+    private String journalpostId;
+
+    public String getJournalpostId() {
+        return journalpostId;
+    }
+
+    public void setJournalpostId(String journalpostId) {
+        this.journalpostId = journalpostId;
+    }
+
+    public SafRequestVariable(String journalpostId) {
+        this.journalpostId = journalpostId;
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/Sak.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/journalpost/internal/Sak.java
@@ -1,0 +1,22 @@
+package no.nav.familie.ks.oppslag.journalpost.internal;
+
+public class Sak {
+    private String arkivsaksnummer;
+    private String arkivsaksystem;
+
+    public Sak() {
+    }
+
+    public Sak(String arkivsaksnummer, String arkivsaksystem) {
+        this.arkivsaksnummer = arkivsaksnummer;
+        this.arkivsaksystem = arkivsaksystem;
+    }
+
+    public String getArkivsaksnummer() {
+        return arkivsaksnummer;
+    }
+
+    public String getArkivsaksystem() {
+        return arkivsaksystem;
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -15,6 +15,7 @@ AKTOERID_URL: #Denne er ikke i bruk da Aktøregisterklienten mockes ut lokalt
 PERSON_V3_URL: https://localhost:8063/soap/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: http://localhost:18321
 MEDL2_URL: #Denne er ikke i bruk da Medl2 mockes ut lokalt
+SAF_URL: http://localhost:18321/rest/saf/graphql
 
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -11,4 +11,4 @@ AKTOERID_URL: https://app-q0.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp-q0.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv-q0.nais.preprod.local
 MEDL2_URL: https://app-q0.adeo.no/medl2/api/v1
-SAF_URL: https://saf-q0.nais.preprod.local/graphql
+SAF_URL: http://saf.q0/graphql

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -11,3 +11,4 @@ AKTOERID_URL: https://app-q0.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp-q0.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv-q0.nais.preprod.local
 MEDL2_URL: https://app-q0.adeo.no/medl2/api/v1
+SAF_URL: https://saf-q0.nais.preprod.local/graphql

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,7 +11,7 @@ AKTOERID_URL: https://app.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv.nais.adeo.no
 MEDL2_URL: https://app.adeo.no/medl2/api/v1
-SAF_URL: https://saf.nais.adeo.no/graphql
+SAF_URL: http://saf/graphql
 
 # Appdynamics
 APPDYNAMICS_CONTROLLER_HOST_NAME: appdynamics.adeo.no

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,6 +11,7 @@ AKTOERID_URL: https://app.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv.nais.adeo.no
 MEDL2_URL: https://app.adeo.no/medl2/api/v1
+SAF_URL: https://saf.nais.adeo.no/graphql
 
 # Appdynamics
 APPDYNAMICS_CONTROLLER_HOST_NAME: appdynamics.adeo.no

--- a/src/test/java/no/nav/familie/ks/oppslag/DevLauncher.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/DevLauncher.java
@@ -16,7 +16,7 @@ public class DevLauncher {
 
     public static void main(String... args) {
         SpringApplication app = new SpringApplicationBuilder(ApplicationConfig.class)
-                .profiles("dev", "mock-sts", "mock-aktor", "mock-medlemskap", "mock-personopplysninger")
+                .profiles("dev", "mock-sts", "mock-aktor", "mock-medlemskap", "mock-personopplysninger", "mock-saf")
                 .build();
         app.run(args);
     }

--- a/src/test/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostControllerTest.java
@@ -1,0 +1,184 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.familie.ks.oppslag.DevLauncher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.ConnectionOptions;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = DevLauncher.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = {"dev", "mock-sts"})
+public class HentJournalpostControllerTest {
+    public static final int MOCK_SERVER_PORT = 18321;
+    public static final String JOURNALPOST_ID = "12345678";
+    public static final String SAKSNUMMER = "87654321";
+    public static final String JOURNALPOST_BASE_URL = "/api/journalpost/";
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this, MOCK_SERVER_PORT);
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private TestRestTemplate restTemplate = new TestRestTemplate();
+    private HttpHeaders headers = new HttpHeaders();
+    @LocalServerPort
+    private int port;
+
+    @Before
+    public void setUp() {
+        HttpEntity<String> entity = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> cookie = restTemplate.exchange(
+                createURLWithPort("/local/cookie"), HttpMethod.GET, entity, String.class);
+        headers.add("Authorization", "Bearer " + cookie.getBody().split("value\":\"")[1].split("\",\"")[0]);
+    }
+
+    @Test
+    public void skal_returnere_saksnummer_og_status_OK() throws IOException {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("POST")
+                                .withPath("/rest/saf/graphql")
+                                .withBody(testdata("gyldigrequest.json"))
+                )
+                .respond(
+                        HttpResponse.response().withBody(testdata("gyldigresponse.json")).withHeaders(
+                                new Header("Content-Type", "application/json"))
+                );
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                createURLWithPort(JOURNALPOST_BASE_URL + JOURNALPOST_ID + "/sak"), HttpMethod.GET, new HttpEntity<String>(null, headers), String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody()).isEqualTo(SAKSNUMMER);
+    }
+
+    @Test
+    public void skal_returnere_status_404_hvis_sak_mangler() throws IOException {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("POST")
+                                .withHeader(new Header("Content-Type", "application/json"))
+                                .withPath("/rest/saf/graphql")
+                )
+                .respond(
+                        HttpResponse.response().withBody(testdata("mangler_sak.json")).withHeaders(
+                                new Header("Content-Type", "application/json"))
+                );
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                createURLWithPort(JOURNALPOST_BASE_URL + JOURNALPOST_ID + "/sak"), HttpMethod.GET, new HttpEntity<String>(null, headers), String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getBody()).isEqualTo("Sak mangler for journalpostId=" + JOURNALPOST_ID);
+    }
+
+    @Test
+    public void skal_returnere_status_404_hvis_sak_ikke_er_GSAK() throws IOException {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("POST")
+                                .withHeader(new Header("Content-Type", "application/json"))
+                                .withPath("/rest/saf/graphql")
+                )
+                .respond(
+                        HttpResponse.response().withBody(testdata("feil_arkivsaksystem.json")).withHeaders(
+                                new Header("Content-Type", "application/json"))
+                );
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                createURLWithPort(JOURNALPOST_BASE_URL + JOURNALPOST_ID + "/sak"), HttpMethod.GET, new HttpEntity<String>(null, headers), String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getBody()).isEqualTo("Sak mangler for journalpostId=" + JOURNALPOST_ID);
+    }
+
+    @Test
+    public void skal_status_404_hvis_journalpost_ikke_finnes() {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("POST")
+                                .withHeader(new Header("Content-Type", "application/json"))
+                                .withPath("/rest/saf/graphql")
+                )
+
+                .respond(
+                        HttpResponse.response().withStatusCode(404)
+                );
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                createURLWithPort(JOURNALPOST_BASE_URL + JOURNALPOST_ID + "/sak"), HttpMethod.GET, new HttpEntity<String>(null, headers), String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getBody()).isEqualTo("Fant ikke journalpost med id=" + JOURNALPOST_ID);
+    }
+
+    @Test
+    public void skal_returnere_500_ved_ukjent_feil() {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("POST")
+                                .withHeader(new Header("Content-Type", "application/json"))
+                                .withPath("/rest/saf/graphql")
+                )
+
+                .respond(
+                        HttpResponse.response().withStatusCode(500).withBody("feilmelding")
+                );
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                createURLWithPort(JOURNALPOST_BASE_URL + JOURNALPOST_ID + "/sak"), HttpMethod.GET, new HttpEntity<String>(null, headers), String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isEqualTo("Feil ved henting av journalpostId=" + JOURNALPOST_ID);
+    }
+
+
+    private String createURLWithPort(String uri) {
+        return "http://localhost:" + port + uri;
+    }
+
+    private String testdata(String filnavn) throws IOException {
+        return Files.readString(new ClassPathResource("saf/" + filnavn).getFile().toPath(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/journalpost/HentJournalpostControllerTest.java
@@ -1,7 +1,9 @@
 package no.nav.familie.ks.oppslag.journalpost;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
 import no.nav.familie.ks.oppslag.DevLauncher;
+import no.nav.security.oidc.test.support.JwtTokenGenerator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,10 +49,7 @@ public class HentJournalpostControllerTest {
 
     @Before
     public void setUp() {
-        HttpEntity<String> entity = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> cookie = restTemplate.exchange(
-                createURLWithPort("/local/cookie"), HttpMethod.GET, entity, String.class);
-        headers.add("Authorization", "Bearer " + cookie.getBody().split("value\":\"")[1].split("\",\"")[0]);
+        headers.setBearerAuth(JwtTokenGenerator.signedJWTAsString("testbruker"));
     }
 
     @Test

--- a/src/test/java/no/nav/familie/ks/oppslag/journalpost/SafClientTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/journalpost/SafClientTestConfig.java
@@ -1,0 +1,33 @@
+package no.nav.familie.ks.oppslag.journalpost;
+
+import no.nav.familie.ks.oppslag.journalpost.internal.Journalpost;
+import no.nav.familie.ks.oppslag.journalpost.internal.SafKlient;
+import no.nav.familie.ks.oppslag.journalpost.internal.Sak;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Configuration
+public class SafClientTestConfig {
+
+    @Bean
+    @Profile("mock-saf")
+    @Primary
+    public SafKlient safKlientMock() {
+        SafKlient klient = mock(SafKlient.class);
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        when(klient.hentJournalpost(stringCaptor.capture())).thenAnswer(invocation -> {
+            String identArg = invocation.getArgument(0);
+
+            return new Journalpost(stringCaptor.getValue(), new Sak("1111" + stringCaptor.getValue(), "GSAK"));
+        });
+        return klient;
+    }
+
+}

--- a/src/test/resources/saf/feil_arkivsaksystem.json
+++ b/src/test/resources/saf/feil_arkivsaksystem.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "journalpost": {
+      "journalpostId": "12345678",
+      "sak": {
+        "arkivsaksystem": "PSAK",
+        "arkivsaksnummer": "87654321",
+        "datoOpprettet": "2019-07-05T14:02:11"
+      }
+    }
+  }
+}

--- a/src/test/resources/saf/gyldigrequest.json
+++ b/src/test/resources/saf/gyldigrequest.json
@@ -1,0 +1,6 @@
+{
+  "query" : "query Journalpost($journalpostId: String!) {journalpost(journalpostId: $journalpostId) {journalpostId sak {arkivsaksystem arkivsaksnummer datoOpprettet}}}",
+  "variables" : {
+    "journalpostId" : "12345678"
+  }
+}

--- a/src/test/resources/saf/gyldigresponse.json
+++ b/src/test/resources/saf/gyldigresponse.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "journalpost": {
+      "journalpostId": "12345678",
+      "sak": {
+        "arkivsaksystem": "GSAK",
+        "arkivsaksnummer": "87654321",
+        "datoOpprettet": "2019-07-05T14:02:11"
+      }
+    }
+  }
+}

--- a/src/test/resources/saf/mangler_sak.json
+++ b/src/test/resources/saf/mangler_sak.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "journalpost": {
+      "journalpostId": "12345678",
+      "sak": null
+    }
+  }
+}


### PR DESCRIPTION
Returnerer saksnummer hvis journalpost eksisterer og har gsak. Det er BRUT001 som lager saksnummeret etter at vi har journalført. Hvis saksnummer eller journalpost ikke eksisterer så får man 404
- Bruker en graphql-tjeneste fra saf for å hente journalpost og hente ut sak.
- returnerer kun sak hvis man finner en gsak.
- i joark så vil denne infoen ligge i T_Saksrelasjon