### PR TITLE
Infotrygd oppslag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <changelist>-SNAPSHOT</changelist>
         <java.version>11</java.version>
         <common-java-modules.version>1.2019.07.11-12.31-0b875ec24c4e</common-java-modules.version>
-        <felles.version>1.0_20191001111015_7b0e1f3</felles.version>
+        <felles.version>1.0_20191004141557_714293c</felles.version>
         <kontrakt.version>1.0_20191001152708_01aaa0c</kontrakt.version>
         <cxf.version>3.3.1</cxf.version>
         <oidc-support.version>0.2.18</oidc-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <changelist>-SNAPSHOT</changelist>
         <java.version>11</java.version>
         <common-java-modules.version>1.2019.07.11-12.31-0b875ec24c4e</common-java-modules.version>
-        <felles.version>1.0_20191004141557_714293c</felles.version>
+        <felles.version>1.0_20191007152733_dff2e9b</felles.version>
         <kontrakt.version>1.0_20191001152708_01aaa0c</kontrakt.version>
         <cxf.version>3.3.1</cxf.version>
         <oidc-support.version>0.2.18</oidc-support.version>

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -6,11 +6,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -30,23 +30,20 @@ public class InfotrygdController {
         this.infotrygdService = infotrygdService;
     }
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(HttpServerErrorException.class)
-    public Map<String, String> handleExceptions(HttpServerErrorException ex) {
+    public ResponseEntity<Map<String, String>> handleExceptions(HttpServerErrorException ex) {
         LOG.warn("Infotrygd-kontantstøtte 5xx-feil: " + ex.getStatusText());
-        return Map.of("error", ex.getStatusText());
+        return new ResponseEntity<Map<String, String>>(Map.of("error", ex.getStatusText()), ex.getStatusCode());
     }
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(HttpClientErrorException.class)
-    public Map<String, String> handleExceptions(HttpClientErrorException ex) {
+    public ResponseEntity<Map<String, String>> handleExceptions(HttpClientErrorException ex) {
         LOG.warn("Infotrygd-kontantstøtte 4xx-feil: " + ex.getStatusText());
-        return Map.of("error", ex.getStatusText());
+        return new ResponseEntity<Map<String, String>>(Map.of("error", ex.getStatusText()), ex.getStatusCode());
     }
 
-    @ResponseStatus(HttpStatus.OK)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, path = "harBarnAktivKontantstotte")
-    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestHeader(name = "Nav-Personident") String fnr) {
-        return infotrygdService.hentAktivKontantstøtteFor(fnr);
+    public ResponseEntity<AktivKontantstøtteInfo> aktivKontantstøtte(@NotNull @RequestHeader(name = "Nav-Personident") String fnr) {
+        return new ResponseEntity<AktivKontantstøtteInfo>(infotrygdService.hentAktivKontantstøtteFor(fnr), HttpStatus.OK);
     }
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -32,13 +32,13 @@ public class InfotrygdController {
 
     @ExceptionHandler(HttpServerErrorException.class)
     public ResponseEntity<Map<String, String>> handleExceptions(HttpServerErrorException ex) {
-        LOG.warn("Infotrygd-kontantstøtte 5xx-feil: " + ex.getStatusText());
+        LOG.error("Infotrygd-kontantstøtte 5xx-feil: " + ex.getStatusText());
         return new ResponseEntity<Map<String, String>>(Map.of("error", ex.getStatusText()), ex.getStatusCode());
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<Map<String, String>> handleExceptions(HttpClientErrorException ex) {
-        LOG.warn("Infotrygd-kontantstøtte 4xx-feil: " + ex.getStatusText());
+        LOG.error("Infotrygd-kontantstøtte 4xx-feil: " + ex.getStatusText());
         return new ResponseEntity<Map<String, String>>(Map.of("error", ex.getStatusText()), ex.getStatusCode());
     }
 

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 @RestController
@@ -31,16 +32,16 @@ public class InfotrygdController {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(HttpServerErrorException.class)
-    public String handleValidationExceptions(HttpServerErrorException ex) {
-        LOG.warn("Infotrygd-kontantstøtte 5xx-feil: ", ex.getResponseBodyAsString());
-        return ex.getResponseBodyAsString();
+    public Map<String, String> handleExceptions(HttpServerErrorException ex) {
+        LOG.warn("Infotrygd-kontantstøtte 5xx-feil: " + ex.getStatusText());
+        return Map.of("error", ex.getStatusText());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(HttpClientErrorException.class)
-    public String handleValidationExceptions(HttpClientErrorException ex) {
-        LOG.warn("Infotrygd-kontantstøtte 4xx-feil: ", ex.getResponseBodyAsString());
-        return ex.getResponseBodyAsString();
+    public Map<String, String> handleExceptions(HttpClientErrorException ex) {
+        LOG.warn("Infotrygd-kontantstøtte 4xx-feil: " + ex.getStatusText());
+        return Map.of("error", ex.getStatusText());
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -45,7 +45,7 @@ public class InfotrygdController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, path = "harBarnAktivKontantstotte")
-    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestParam(name = "fnr") String fnr) {
+    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestHeader(name = "fnr") String fnr) {
         return infotrygdService.hentAktivKontantstøtteFor(fnr);
     }
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -1,0 +1,51 @@
+package no.nav.familie.ks.oppslag.infotrygd;
+
+import no.nav.familie.ks.oppslag.infotrygd.domene.AktivKontantstøtteInfo;
+import no.nav.security.oidc.api.ProtectedWithClaims;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+
+import javax.validation.constraints.NotNull;
+
+@RestController
+@ProtectedWithClaims(issuer = "intern")
+@RequestMapping("/api/infotrygd")
+public class InfotrygdController {
+    private static final Logger LOG = LoggerFactory.getLogger(InfotrygdController.class);
+
+    private InfotrygdService infotrygdService;
+
+    public InfotrygdController(InfotrygdService infotrygdService) {
+        this.infotrygdService = infotrygdService;
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(HttpServerErrorException.class)
+    public String handleValidationExceptions(HttpServerErrorException ex) {
+        LOG.warn("Infotrygd-kontantstøtte 5xx-feil: ", ex.getResponseBodyAsString());
+        return ex.getResponseBodyAsString();
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(HttpClientErrorException.class)
+    public String handleValidationExceptions(HttpClientErrorException ex) {
+        LOG.warn("Infotrygd-kontantstøtte 4xx-feil: ", ex.getResponseBodyAsString());
+        return ex.getResponseBodyAsString();
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, path = "harBarnAktivKontantstotte")
+    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestParam(name = "fnr") String fnr) {
+        return infotrygdService.hentAktivKontantstøtteFor(fnr);
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdController.java
@@ -46,7 +46,7 @@ public class InfotrygdController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, path = "harBarnAktivKontantstotte")
-    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestHeader(name = "fnr") String fnr) {
+    public AktivKontantstøtteInfo aktivKontantstøtte(@NotNull @RequestHeader(name = "Nav-Personident") String fnr) {
         return infotrygdService.hentAktivKontantstøtteFor(fnr);
     }
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
@@ -15,11 +15,15 @@ public class InfotrygdService {
     private RestTemplate restTemplate = new RestTemplate();
     private AccessTokenClient accessTokenClient;
     private String scope;
+    private String infotrygdURL;
 
     @Autowired
-    public InfotrygdService(AccessTokenClient accessTokenClient, @Value("${INFOTRYGD_KS_SCOPE}") String scope) {
+    public InfotrygdService(AccessTokenClient accessTokenClient, 
+                            @Value("${INFOTRYGD_KS_SCOPE}") String scope, 
+                            @Value("${INFOTRYGD_URL}") String infotrygdURL) {
         this.accessTokenClient = accessTokenClient;
         this.scope = scope;
+        this.infotrygdURL = infotrygdURL;
     }
 
     AktivKontantstøtteInfo hentAktivKontantstøtteFor(String fnr) {
@@ -28,7 +32,7 @@ public class InfotrygdService {
         headers.add("fnr", fnr);
         var entity = new HttpEntity(headers);
 
-        var response = restTemplate.exchange("https://infotrygd-kontantstotte/v1/harBarnAktivKontantstotte",
+        var response = restTemplate.exchange(String.format("%s/v1/harBarnAktivKontantstotte", infotrygdURL),
                                         HttpMethod.GET,
                                         entity,
                                         AktivKontantstøtteInfo.class);

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
@@ -29,6 +29,7 @@ public class InfotrygdService {
     AktivKontantstøtteInfo hentAktivKontantstøtteFor(String fnr) {
         var headers = new HttpHeaders();
         headers.setBearerAuth(accessTokenClient.getAccessToken(scope).access_token);
+        headers.add("Accept", "application/json");
         headers.add("fnr", fnr);
         var entity = new HttpEntity(headers);
 

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdService.java
@@ -1,0 +1,38 @@
+package no.nav.familie.ks.oppslag.infotrygd;
+
+import no.nav.familie.http.azure.AccessTokenClient;
+import no.nav.familie.ks.oppslag.infotrygd.domene.AktivKontantstøtteInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class InfotrygdService {
+    private RestTemplate restTemplate = new RestTemplate();
+    private AccessTokenClient accessTokenClient;
+    private String scope;
+
+    @Autowired
+    public InfotrygdService(AccessTokenClient accessTokenClient, @Value("${INFOTRYGD_KS_SCOPE}") String scope) {
+        this.accessTokenClient = accessTokenClient;
+        this.scope = scope;
+    }
+
+    AktivKontantstøtteInfo hentAktivKontantstøtteFor(String fnr) {
+        var headers = new HttpHeaders();
+        headers.setBearerAuth(accessTokenClient.getAccessToken(scope).access_token);
+        headers.add("fnr", fnr);
+        var entity = new HttpEntity(headers);
+
+        var response = restTemplate.exchange("https://infotrygd-kontantstotte/v1/harBarnAktivKontantstotte",
+                                        HttpMethod.GET,
+                                        entity,
+                                        AktivKontantstøtteInfo.class);
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -1,13 +1,12 @@
 package no.nav.familie.ks.oppslag.infotrygd.domene;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AktivKontantstøtteInfo {
     private Boolean harAktivKontantstotte;
 
     public AktivKontantstøtteInfo() {
-    }
-
-    public AktivKontantstøtteInfo(boolean harAktivKontantstotte) {
-        this.harAktivKontantstotte = harAktivKontantstotte;
     }
 
     public Boolean getHarAktivKontantstotte() {

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -3,6 +3,9 @@ package no.nav.familie.ks.oppslag.infotrygd.domene;
 public class AktivKontantstøtteInfo {
     private Boolean harAktivKontantstotte;
 
+    public AktivKontantstøtteInfo() {
+    }
+
     public AktivKontantstøtteInfo(boolean harAktivKontantstotte) {
         this.harAktivKontantstotte = harAktivKontantstotte;
     }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -1,13 +1,13 @@
 package no.nav.familie.ks.oppslag.infotrygd.domene;
 
 public class AktivKontantstøtteInfo {
-    private boolean harAktivKontantstøtte;
+    private boolean harAktivKontantstotte;
 
-    public AktivKontantstøtteInfo(boolean harAktivKontantstøtte) {
-        this.harAktivKontantstøtte = harAktivKontantstøtte;
+    public AktivKontantstøtteInfo(boolean harAktivKontantstotte) {
+        this.harAktivKontantstotte = harAktivKontantstotte;
     }
 
-    public boolean getHarAktivKontantstøtte() {
-        return harAktivKontantstøtte;
+    public boolean getHarAktivKontantstotte() {
+        return harAktivKontantstotte;
     }
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -1,8 +1,5 @@
 package no.nav.familie.ks.oppslag.infotrygd.domene;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AktivKontantstøtteInfo {
     private Boolean harAktivKontantstotte;
 

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -1,13 +1,17 @@
 package no.nav.familie.ks.oppslag.infotrygd.domene;
 
 public class AktivKontantstøtteInfo {
-    private boolean harAktivKontantstotte;
+    private Boolean harAktivKontantstotte;
 
     public AktivKontantstøtteInfo(boolean harAktivKontantstotte) {
         this.harAktivKontantstotte = harAktivKontantstotte;
     }
 
-    public boolean getHarAktivKontantstotte() {
+    public Boolean getHarAktivKontantstotte() {
         return harAktivKontantstotte;
+    }
+
+    public void setHarAktivKontantstotte(Boolean harAktivKontantstotte) {
+        this.harAktivKontantstotte = harAktivKontantstotte;
     }
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/infotrygd/domene/AktivKontantstøtteInfo.java
@@ -1,0 +1,13 @@
+package no.nav.familie.ks.oppslag.infotrygd.domene;
+
+public class AktivKontantstøtteInfo {
+    private boolean harAktivKontantstøtte;
+
+    public AktivKontantstøtteInfo(boolean harAktivKontantstøtte) {
+        this.harAktivKontantstøtte = harAktivKontantstøtte;
+    }
+
+    public boolean getHarAktivKontantstøtte() {
+        return harAktivKontantstøtte;
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,9 +6,9 @@ no.nav.security.oidc:
     cookie_name: localhost-idtoken
 
 AAD_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
-TENANT: ""
 CLIENT_ID: ""
 CLIENT_SECRET: ""
+INFOTRYGD_KS_SCOPE: ""
 
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
 AKTOERID_URL: #Denne er ikke i bruk da Aktøregisterklienten mockes ut lokalt

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,7 +14,7 @@ SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvid
 AKTOERID_URL: #Denne er ikke i bruk da Aktøregisterklienten mockes ut lokalt
 PERSON_V3_URL: #Denne er ikke i bruk da PersonV3 mockes ut lokalt
 DOKARKIV_V1_URL: http://localhost:18321
-INFOTRYGD_URL:
+INFOTRYGD_URL: http://localhost:18321
 
 MEDL2_URL: #Denne er ikke i bruk da Medl2 mockes ut lokalt
 SAF_URL: http://localhost:18321/rest/saf/graphql

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,7 +14,6 @@ SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvid
 AKTOERID_URL: #Denne er ikke i bruk da Aktøregisterklienten mockes ut lokalt
 PERSON_V3_URL: #Denne er ikke i bruk da PersonV3 mockes ut lokalt
 DOKARKIV_V1_URL: http://localhost:18321
-INFOTRYGD_URL: http://localhost:18321
 
 MEDL2_URL: #Denne er ikke i bruk da Medl2 mockes ut lokalt
 SAF_URL: http://localhost:18321/rest/saf/graphql

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,6 +14,7 @@ SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvid
 AKTOERID_URL: #Denne er ikke i bruk da Aktøregisterklienten mockes ut lokalt
 PERSON_V3_URL: #Denne er ikke i bruk da PersonV3 mockes ut lokalt
 DOKARKIV_V1_URL: http://localhost:18321
+INFOTRYGD_URL:
 
 MEDL2_URL: #Denne er ikke i bruk da Medl2 mockes ut lokalt
 SAF_URL: http://localhost:18321/rest/saf/graphql

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -6,11 +6,14 @@ no.nav.security.oidc:
     cookie_name: ID_token
 
 AAD_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
+CLIENT_ID: ${CLIENT_ID}
+CLIENT_SECRET: ${CLIENT_SECRET}
+INFOTRYGD_KS_SCOPE: ${INFOTRYGD_KS_SCOPE}
+
 SECURITYTOKENSERVICE_URL: https://sts-q1.preprod.local/SecurityTokenServiceProvider/
 AKTOERID_URL: https://app-q0.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp-q0.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv-q0.nais.preprod.local
-INFOTRYGD_URL: https://infotrygd-kontantstotte.nais.preprod.local
 MEDL2_URL: https://app-q0.adeo.no/medl2/api/v1
 SAF_URL: http://saf.q0/graphql
 BEHANDLE_OPPGAVE_V1_URL: https://wasapp-q0.adeo.no/nav-gsak-ws/BehandleOppgaveV1

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -10,6 +10,7 @@ SECURITYTOKENSERVICE_URL: https://sts-q1.preprod.local/SecurityTokenServiceProvi
 AKTOERID_URL: https://app-q0.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp-q0.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv-q0.nais.preprod.local
+INFOTRYGD_URL: https://infotrygd-kontantstotte.nais.preprod.local
 MEDL2_URL: https://app-q0.adeo.no/medl2/api/v1
 SAF_URL: http://saf.q0/graphql
 BEHANDLE_OPPGAVE_V1_URL: https://wasapp-q0.adeo.no/nav-gsak-ws/BehandleOppgaveV1

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -6,11 +6,14 @@ no.nav.security.oidc:
     cookie_name: ID_token
 
 AAD_URL: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0/token
+CLIENT_ID: ${CLIENT_ID}
+CLIENT_SECRET: ${CLIENT_SECRET}
+INFOTRYGD_KS_SCOPE: ${INFOTRYGD_KS_SCOPE}
+
 SECURITYTOKENSERVICE_URL: https://sts.adeo.no/SecurityTokenServiceProvider/
 AKTOERID_URL: https://app.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv.nais.adeo.no
-INFOTRYGD_URL: https://infotrygd-kontantstotte.nais.adeo.no
 MEDL2_URL: https://app.adeo.no/medl2/api/v1
 SAF_URL: http://saf/graphql
 BEHANDLE_OPPGAVE_V1_URL: https://wasapp.adeo.no/nav-gsak-ws/BehandleOppgaveV1

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -10,6 +10,7 @@ SECURITYTOKENSERVICE_URL: https://sts.adeo.no/SecurityTokenServiceProvider/
 AKTOERID_URL: https://app.adeo.no/aktoerregister/api/v1
 PERSON_V3_URL: https://wasapp.adeo.no/tpsws/ws/Person/v3
 DOKARKIV_V1_URL: https://dokarkiv.nais.adeo.no
+INFOTRYGD_URL: https://infotrygd-kontantstotte.nais.adeo.no
 MEDL2_URL: https://app.adeo.no/medl2/api/v1
 SAF_URL: http://saf/graphql
 BEHANDLE_OPPGAVE_V1_URL: https://wasapp.adeo.no/nav-gsak-ws/BehandleOppgaveV1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,4 +16,4 @@ management:
   metrics.export.prometheus.enabled: true
 
 STS_URL: http://security-token-service.default.svc.nais.local
-INFOTRYGD_URL: https://infotrygd-kontantstotte
+INFOTRYGD_URL: http://infotrygd-kontantstotte

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,3 +16,4 @@ management:
   metrics.export.prometheus.enabled: true
 
 STS_URL: http://security-token-service.default.svc.nais.local
+INFOTRYGD_URL: https://infotrygd-kontantstotte

--- a/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
@@ -1,0 +1,30 @@
+package no.nav.familie.ks.oppslag.infotrygd;
+
+import no.nav.familie.ks.oppslag.OppslagSpringRunnerTest;
+import no.nav.familie.ks.oppslag.infotrygd.domene.AktivKontantstøtteInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles(profiles = {"dev", "mock-sts"})
+public class InfotrygdControllerTest extends OppslagSpringRunnerTest {
+    @Before
+    public void setUp() {
+        headers.setBearerAuth(getLokalTestToken());
+    }
+    
+    @Test
+    public void skal_gi_bad_request_hvis_fnr_mangler() {
+        var response = restTemplate.exchange(
+                localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity(headers), AktivKontantstøtteInfo.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
@@ -48,7 +48,7 @@ public class InfotrygdControllerTest extends OppslagSpringRunnerTest {
 
     @Test
     public void skal_feile_når_fnr_ikke_er_et_tall() {
-        headers.add("fnr", "foo");
+        headers.add("Nav-Personident", "foo");
 
         var response = restTemplate.exchange(
                 localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity<>(headers), AktivKontantstøtteInfo.class

--- a/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
@@ -1,30 +1,113 @@
 package no.nav.familie.ks.oppslag.infotrygd;
 
+import no.nav.familie.http.azure.AccessTokenClient;
+import no.nav.familie.http.azure.AccessTokenDto;
 import no.nav.familie.ks.oppslag.OppslagSpringRunnerTest;
 import no.nav.familie.ks.oppslag.infotrygd.domene.AktivKontantstøtteInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpServerErrorException;
 
-@ActiveProfiles(profiles = {"dev", "mock-sts"})
+@ActiveProfiles(profiles = { "dev" })
 public class InfotrygdControllerTest extends OppslagSpringRunnerTest {
+        public static final int MOCK_SERVER_PORT = 18321;
+        AccessTokenClient accessTokenClient = mock(AccessTokenClient.class);
+        InfotrygdService infotrygdService = new InfotrygdService(accessTokenClient, "", "http://localhost:" + MOCK_SERVER_PORT);
+
+        @Rule
+        public MockServerRule mockServerRule = new MockServerRule(this, MOCK_SERVER_PORT);
+
     @Before
     public void setUp() {
         headers.setBearerAuth(getLokalTestToken());
+        when(accessTokenClient.getAccessToken("")).thenReturn(new AccessTokenDto("", "", 0));
     }
     
     @Test
     public void skal_gi_bad_request_hvis_fnr_mangler() {
         var response = restTemplate.exchange(
-                localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity(headers), AktivKontantstøtteInfo.class
+                localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity<>(headers), AktivKontantstøtteInfo.class
         );
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void skal_feile_når_fnr_ikke_er_et_tall() {
+        headers.add("fnr", "foo");
+
+        var response = restTemplate.exchange(
+                localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity<>(headers), AktivKontantstøtteInfo.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+    
+    @Test
+    public void skal_korrekt_behandle_returobjekt() {
+        spesifiserResponsFraInfotrygd("{ \"harAktivKontantstotte\": true }");
+        var aktivKontantstøtteInfo = infotrygdService.hentAktivKontantstøtteFor("12345678901");
+        assertThat(aktivKontantstøtteInfo.getHarAktivKontantstotte()).isEqualTo(true);
+    }
+
+    @Test
+    public void skal_tolerere_returobjekt_med_flere_verdier() {
+        spesifiserResponsFraInfotrygd("{ \"harAktivKontantstotte\": true, \"foo\": 42 }");
+        var aktivKontantstøtteInfo = infotrygdService.hentAktivKontantstøtteFor("12345678901");
+        assertThat(aktivKontantstøtteInfo.getHarAktivKontantstotte()).isEqualTo(true);
+    }
+
+    @Test
+    public void skal_feile_når_respons_mangler() {
+        spesifiserResponsFraInfotrygd("");
+
+        assertThatThrownBy(() -> {
+                infotrygdService.hentAktivKontantstøtteFor("12345678901"); 
+        }).isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    public void skal_feile_når_returobjekt_er_tomt() {
+        spesifiserResponsFraInfotrygd("{}");
+
+        assertThatThrownBy(() -> {
+                infotrygdService.hentAktivKontantstøtteFor("12345678901"); 
+        }).isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    public void skal_feile_når_returobjekt_har_feil_type() {
+        spesifiserResponsFraInfotrygd("{ \"harAKtivKontantstotte\": 42 }");
+
+        assertThatThrownBy(() -> {
+                infotrygdService.hentAktivKontantstøtteFor("12345678901"); 
+        }).isInstanceOf(HttpServerErrorException.class);
+    }
+
+    private void spesifiserResponsFraInfotrygd(String respons) {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("GET")
+                                .withPath("/v1/harBarnAktivKontantstotte")
+                )
+                .respond(
+                        HttpResponse.response().withHeader("Content-Type", "application/json").withBody(respons)
+                );
     }
 }

--- a/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/infotrygd/InfotrygdControllerTest.java
@@ -54,7 +54,7 @@ public class InfotrygdControllerTest extends OppslagSpringRunnerTest {
                 localhost("/api/infotrygd/harBarnAktivKontantstotte"), HttpMethod.GET, new HttpEntity<>(headers), AktivKontantstøtteInfo.class
         );
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
     
     @Test


### PR DESCRIPTION
Implementasjon av integrasjon mot infotrygd-kontantstotte (https://github.com/navikt/infotrygd-kontantstotte).

Endepunktet "/api/infotrygd/harBarnAktivKontantstotte" benyttes for å gi svar på om barnet pr. nå mottar kontantstøtte. Den returnerer et json-objekt på formen { harAktivKontantstotte: <bool> }.

familie-felles oppdateres pga. forbedret funksjonalitet mot Azure.

