### PR TITLE
Logge finnOppgave requestUrl 

### DIFF
--- a/src/main/java/no/nav/familie/ks/oppslag/oppgave/OppgaveController.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/oppgave/OppgaveController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @ProtectedWithClaims(issuer = "intern")
 @RequestMapping("/api/oppgave")
@@ -30,10 +32,10 @@ public class OppgaveController {
     }
 
     @ExceptionHandler(OppgaveIkkeFunnetException.class)
-    public ResponseEntity handleOppgaveIkkeFunnetException(RuntimeException e) {
+    public ResponseEntity<Map<String, String>> handleOppgaveIkkeFunnetException(RuntimeException e) {
         String errorMessage = "Feil ved oppdatering av Gosysoppgave: " + ExceptionUtils.getStackTrace(e);
         LOG.warn(errorMessage, e);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).header("message", e.getMessage()).build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Ingen oppgaver funnet " + e.getMessage()));
     }
 
 }

--- a/src/main/java/no/nav/familie/ks/oppslag/oppgave/internal/OppgaveClient.java
+++ b/src/main/java/no/nav/familie/ks/oppslag/oppgave/internal/OppgaveClient.java
@@ -68,7 +68,7 @@ public class OppgaveClient {
     private OppgaveJsonDto requestOppgaveJson(URI requestUrl) {
         var response = getRequest(requestUrl, FinnOppgaveResponseDto.class);
         if (Objects.requireNonNull(response.getBody()).getOppgaver().isEmpty()) {
-            throw new OppgaveIkkeFunnetException("Mislykket finnOppgave request med url: " + requestUrl.getPath());
+            throw new OppgaveIkkeFunnetException("Mislykket finnOppgave request med url: " + requestUrl);
         }
         return response.getBody().getOppgaver().get(0);
     }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -19,7 +19,6 @@ EGEN_ANSATT_V1_URL: #Mockes ut lokalt
 
 MEDL2_URL: #Denne er ikke i bruk da Medl2 mockes ut lokalt
 SAF_URL: http://localhost:18321/rest/saf
-OPPGAVE_URL: # må mockes ut lokalt
-
+OPPGAVE_URL: http://localhost:18321
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw

--- a/src/test/java/no/nav/familie/ks/oppslag/oppgave/OppgaveControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/oppgave/OppgaveControllerTest.java
@@ -50,7 +50,7 @@ public class OppgaveControllerTest extends OppslagSpringRunnerTest {
                         HttpRequest
                                 .request()
                                 .withMethod("GET")
-                                .withPath("/oppgaver")
+                                .withPath("/api/v1/oppgaver")
                 )
                 .respond(
                         HttpResponse.response()
@@ -71,7 +71,7 @@ public class OppgaveControllerTest extends OppslagSpringRunnerTest {
                         HttpRequest
                                 .request()
                                 .withMethod("GET")
-                                .withPath("/oppgaver")
+                                .withPath("/api/v1/oppgaver")
                 )
                 .respond(
                         HttpResponse.notFoundResponse()
@@ -92,7 +92,7 @@ public class OppgaveControllerTest extends OppslagSpringRunnerTest {
                         HttpRequest
                                 .request()
                                 .withMethod("GET")
-                                .withPath("/oppgaver")
+                                .withPath("/api/v1/oppgaver")
                 )
                 .respond(
                         HttpResponse.response().withBody(gyldigOppgaveResponse()).withHeaders(
@@ -105,7 +105,7 @@ public class OppgaveControllerTest extends OppslagSpringRunnerTest {
                 localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST, new HttpEntity<>(test, headers), String.class
         );
         assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s ->
-                s.contains("OppgaveIkkeFunnetException: Mislykket finnOppgave request med url: http://localhost:18321/oppgaver?aktoerId=1234567891011")
+                s.contains("OppgaveIkkeFunnetException: Mislykket finnOppgave request med url: http://localhost:18321/api/v1/oppgaver?aktoerId=1234567891011")
         );
     }
 

--- a/src/test/java/no/nav/familie/ks/oppslag/oppgave/OppgaveControllerTest.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/oppgave/OppgaveControllerTest.java
@@ -6,20 +6,34 @@ import no.nav.familie.ks.kontrakter.oppgave.Oppgave;
 import no.nav.familie.ks.oppslag.OppslagSpringRunnerTest;
 import no.nav.familie.ks.oppslag.config.ApiExceptionHandler;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles(profiles = {"dev", "mock-oppgave", "mock-aktor"})
+@ActiveProfiles(profiles = {"dev", "mock-sts", "mock-aktor"})
 public class OppgaveControllerTest extends OppslagSpringRunnerTest {
-    Logger oppgaveControllerLogger = (Logger) LoggerFactory.getLogger(OppgaveController.class);
-    Logger exceptionHandler = (Logger) LoggerFactory.getLogger(ApiExceptionHandler.class);
+    private static final String OPPDATER_OPPGAVE_URL = "/api/oppgave/oppdater";
+    private static final Integer MOCK_SERVER_PORT = 18321;
 
-    public static final String OPPDATER_OPPGAVE_URL = "/api/oppgave/oppdater";
+    private Logger oppgaveControllerLogger = (Logger) LoggerFactory.getLogger(OppgaveController.class);
+    private Logger exceptionHandler = (Logger) LoggerFactory.getLogger(ApiExceptionHandler.class);
+
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this, MOCK_SERVER_PORT);
 
     @Before
     public void setup() {
@@ -31,41 +45,71 @@ public class OppgaveControllerTest extends OppslagSpringRunnerTest {
 
     @Test
     public void skal_logge_stack_trace_ved_NullPointerException() {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("GET")
+                                .withPath("/oppgaver")
+                )
+                .respond(
+                        HttpResponse.response()
+                );
+
         Oppgave test = new Oppgave("1234567891011", "1", null, "test NPE");
 
         restTemplate.exchange(
-                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST,new HttpEntity<>(test, headers), String.class
+                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST, new HttpEntity<>(test, headers), String.class
         );
-        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s -> s.contains("java.lang.NullPointerException\n\tat no.nav.familie.ks.oppslag.oppgave"));
+        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s -> s.contains("java.lang.NullPointerException\n\tat"));
     }
 
     @Test
     public void skal_skrive_til_logg_når_det_oppstår_RestClientException() {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("GET")
+                                .withPath("/oppgaver")
+                )
+                .respond(
+                        HttpResponse.notFoundResponse()
+                );
+
         Oppgave test = new Oppgave("1234567891011", "1", null, "test RestClientException");
 
         restTemplate.exchange(
-                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST,new HttpEntity<>(test, headers), String.class
+                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST, new HttpEntity<>(test, headers), String.class
         );
         assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s -> s.contains("HttpClientErrorException"));
     }
 
     @Test
-    public void skal_skrive_til_logg_hvis_oppgave_ikke_ble_funnet() {
+    public void skal_skrive_til_logg_hvis_oppgave_ikke_ble_funnet() throws IOException {
+        mockServerRule.getClient()
+                .when(
+                        HttpRequest
+                                .request()
+                                .withMethod("GET")
+                                .withPath("/oppgaver")
+                )
+                .respond(
+                        HttpResponse.response().withBody(gyldigOppgaveResponse()).withHeaders(
+                                new Header("Content-Type", "application/json"))
+                );
+
         Oppgave test = new Oppgave("1234567891011", "1", null, "test oppgave ikke funnet");
 
         restTemplate.exchange(
-                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST,new HttpEntity<>(test, headers), String.class
+                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST, new HttpEntity<>(test, headers), String.class
         );
-        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s -> s.contains("OppgaveIkkeFunnetException"));
+        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s ->
+                s.contains("OppgaveIkkeFunnetException: Mislykket finnOppgave request med url: http://localhost:18321/oppgaver?aktoerId=1234567891011")
+        );
     }
 
-    @Test
-    public void skal_skrive_til_logg_ved_generell_feil() {
-        Oppgave test = new Oppgave("1234567891011", "1", null, "test generell feil");
-
-        restTemplate.exchange(
-                localhost(OPPDATER_OPPGAVE_URL), HttpMethod.POST,new HttpEntity<>(test, headers), String.class
-        );
-        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).anyMatch(s -> s.contains("RuntimeException"));
+    private String gyldigOppgaveResponse() throws IOException {
+        return Files.readString(new ClassPathResource("oppgave/tom_response.json").getFile().toPath(), StandardCharsets.UTF_8);
     }
 }

--- a/src/test/resources/oppgave/tom_response.json
+++ b/src/test/resources/oppgave/tom_response.json
@@ -1,0 +1,4 @@
+{
+  "antallTreffTotalt": 0,
+  "oppgaver": []
+}


### PR DESCRIPTION
* fjernet '.getPath()' fra requestUrl for å få med "queryParmas" i log-utskriften ved feil.

* skrevet om testene til å benytte MockServerRule istedenfor å mocke ut OppgaveClient'en