### PR TITLE
Bedre mockdata for aktør, personinfo og personhistorikk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <java.version>11</java.version>
         <common-java-modules.version>1.2019.07.11-12.31-0b875ec24c4e</common-java-modules.version>
         <felles.version>1.0_20191007152733_dff2e9b</felles.version>
-        <kontrakt.version>1.0_20191018144642_dca9821</kontrakt.version>
+        <kontrakt.version>1.0_20191024145448_d452ee4</kontrakt.version>
         <cxf.version>3.3.1</cxf.version>
         <oidc-support.version>0.2.18</oidc-support.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>

--- a/src/test/java/no/nav/familie/ks/oppslag/aktør/config/AktørClientTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/aktør/config/AktørClientTestConfig.java
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.oppslag.aktør.config;
 
+import no.nav.familie.ks.kontrakter.søknad.testdata.SøknadTestdata;
 import no.nav.familie.ks.oppslag.aktør.domene.Aktør;
 import no.nav.familie.ks.oppslag.aktør.domene.Ident;
 import no.nav.familie.ks.oppslag.aktør.internal.AktørResponse;
@@ -23,23 +24,60 @@ public class AktørClientTestConfig {
     public AktørregisterClient aktørregisterClientMock() throws Exception {
         AktørregisterClient aktørregisterClient = mock(AktørregisterClient.class);
         ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
-        Ident testIdent = new Ident().withIdent("1000011111111").withGjeldende(true);
 
         when(aktørregisterClient.hentAktørId(stringCaptor.capture())).thenAnswer(invocation -> {
             String identArg = invocation.getArgument(0);
 
             return new AktørResponse()
-                    .withAktør(identArg, new Aktør().withIdenter(Collections.singletonList(testIdent)));
+                    .withAktør(identArg, new Aktør().withIdenter(Collections.singletonList(finnRiktigAktørId(identArg))));
         });
 
         when(aktørregisterClient.hentPersonIdent(stringCaptor.capture())).thenAnswer(invocation -> {
             String identArg = invocation.getArgument(0);
 
             return new AktørResponse()
-                    .withAktør(identArg, new Aktør().withIdenter(Collections.singletonList(testIdent)));
+                    .withAktør(identArg, new Aktør().withIdenter(Collections.singletonList(finnRiktigPersonIdent(identArg))));
         });
 
         doNothing().when(aktørregisterClient).ping();
         return aktørregisterClient;
+    }
+
+    private Ident finnRiktigAktørId(String personIdent) {
+        switch (personIdent) {
+            case SøknadTestdata.morPersonident:
+                return new Ident().withIdent(SøknadTestdata.morAktørId).withGjeldende(true);
+            case SøknadTestdata.barnPersonident:
+                return new Ident().withIdent(SøknadTestdata.barnAktørId).withGjeldende(true);
+            case SøknadTestdata.farPersonident:
+                return new Ident().withIdent(SøknadTestdata.farAktørId).withGjeldende(true);
+            case SøknadTestdata.utenlandskMorPersonident:
+                return new Ident().withIdent(SøknadTestdata.utenlandskMorAktørId).withGjeldende(true);
+            case SøknadTestdata.utenlandskBarnPersonident:
+                return new Ident().withIdent(SøknadTestdata.utenlandskBarnAktørId).withGjeldende(true);
+            case SøknadTestdata.utenlandskFarPersonident:
+                return new Ident().withIdent(SøknadTestdata.utenlandskFarAktørId).withGjeldende(true);
+            default:
+                return new Ident().withIdent("1000011111111").withGjeldende(true);
+        }
+    }
+
+    private Ident finnRiktigPersonIdent(String aktørId) {
+        switch (aktørId) {
+            case SøknadTestdata.morAktørId:
+                return new Ident().withIdent(SøknadTestdata.morPersonident).withGjeldende(true);
+            case SøknadTestdata.barnAktørId:
+                return new Ident().withIdent(SøknadTestdata.barnPersonident).withGjeldende(true);
+            case SøknadTestdata.farAktørId:
+                return new Ident().withIdent(SøknadTestdata.farPersonident).withGjeldende(true);
+            case SøknadTestdata.utenlandskMorAktørId:
+                return new Ident().withIdent(SøknadTestdata.utenlandskMorPersonident).withGjeldende(true);
+            case SøknadTestdata.utenlandskBarnAktørId:
+                return new Ident().withIdent(SøknadTestdata.utenlandskBarnPersonident).withGjeldende(true);
+            case SøknadTestdata.utenlandskFarAktørId:
+                return new Ident().withIdent(SøknadTestdata.utenlandskFarPersonident).withGjeldende(true);
+            default:
+                return new Ident().withIdent("10000111111").withGjeldende(true);
+        }
     }
 }

--- a/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
@@ -50,18 +50,19 @@ public class PersonopplysningerTestConfig {
 
         when(personConsumer.hentPersonhistorikkResponse(historikkRequestCaptor.capture())).thenAnswer(invocation -> {
             PersonIdent personIdent = (PersonIdent) historikkRequestCaptor.getValue().getAktoer();
-            if (personIdent.getIdent().getIdent().equals(SøknadTestdata.barnPersonident)) {
+            if (SøknadTestdata.barnPersonident.equals(personIdent.getIdent().getIdent())) {
                 return hentPersonhistorikkResponseBarn();
             } else {
                 return hentPersonHistorikkResponse(personIdent.getIdent().getIdent().equals(SøknadTestdata.morPersonident));
             }
         });
+
         when(personConsumer.hentPersonResponse(personRequestCaptor.capture())).thenAnswer(invocation -> {
             PersonIdent personIdent = (PersonIdent) personRequestCaptor.getValue().getAktoer();
 
-            if (personIdent.getIdent().getIdent().equals(SøknadTestdata.morPersonident)) {
+            if (SøknadTestdata.morPersonident.equals(personIdent.getIdent().getIdent())) {
                 return hentPersonResponseForMor();
-            } else if (personIdent.getIdent().getIdent().equals(SøknadTestdata.barnPersonident)) {
+            } else if (SøknadTestdata.barnPersonident.equals(personIdent.getIdent().getIdent())) {
                 return hentPersonResponseForBarn();
             } else {
                 return hentPersonResponseForFar();
@@ -111,57 +112,54 @@ public class PersonopplysningerTestConfig {
     }
 
     private Person hentPersoninfoMor() {
-        Bruker person = new Bruker();
-        person
-                .withBostedsadresse(NORSK_ADRESSE)
+        Bruker mor = hentStandardPersoninfo();
+        mor
                 .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("K")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
-                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN"))
                 .withHarFraRolleI(hentFamilierelasjonerMor())
-                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
-                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
-                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
                 .withFoedselsdato(hentFoedselsdato("1990-01-01"))
                 .withAktoer(MOR_PERSON_IDENT);
 
-        return person;
+        return mor;
     }
 
     private Person hentPersoninfoFar() {
-        Bruker person = new Bruker();
-        person
-                .withBostedsadresse(NORSK_ADRESSE)
+        Bruker far = hentStandardPersoninfo();
+        far
                 .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("M")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
-                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("EKTEMANN TESTESEN"))
                 .withHarFraRolleI(hentFamilierelasjonerFar())
-                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
-                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
-                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
                 .withFoedselsdato(hentFoedselsdato("1990-01-01"))
                 .withAktoer(FAR_PERSON_IDENT);
 
-        return person;
+        return far;
     }
 
     private Person hentPersoninfoBarn() {
-        Bruker barn = new Bruker();
+        Bruker barn = hentStandardPersoninfo();
         barn
-                .withBostedsadresse(NORSK_ADRESSE)
                 .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("K")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("UGIF")))
-                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("BARN TESTESEN"))
                 .withHarFraRolleI(hentFamilierelasjonerBarn())
-                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
-                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
-                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
                 .withFoedselsdato(hentFoedselsdato("2018-05-01"))
                 .withAktoer(BARN_PERSON_IDENT);
 
         return barn;
+    }
+
+    private Bruker hentStandardPersoninfo() {
+        Bruker person = new Bruker();
+        person
+                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
+                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
+                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
+                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
+                .withBostedsadresse(NORSK_ADRESSE);
+
+        return person;
     }
 
     private Collection<Familierelasjon> hentFamilierelasjonerMor() {

--- a/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
@@ -1,11 +1,15 @@
 package no.nav.familie.ks.oppslag.personopplysning;
 
+import no.nav.familie.ks.kontrakter.søknad.testdata.SøknadTestdata;
 import no.nav.familie.ks.oppslag.felles.ws.DateUtil;
 import no.nav.familie.ks.oppslag.personopplysning.internal.PersonConsumer;
 import no.nav.tjeneste.virksomhet.person.v3.binding.*;
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.*;
+import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonRequest;
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonResponse;
+import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonhistorikkRequest;
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonhistorikkResponse;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -22,9 +26,9 @@ import static org.mockito.Mockito.*;
 @Configuration
 public class PersonopplysningerTestConfig {
 
-    private static final String FNR = "12345678911";
     private static final LocalDate TOM = LocalDate.now();
     private static final LocalDate FOM = TOM.minusYears(5);
+    private static final LocalDate FOM_BARNET = LocalDate.of(2018,5,1);
     private static final Landkoder NORGE = new Landkoder().withValue("NOR");
     private static final Bostedsadresse NORSK_ADRESSE = new Bostedsadresse()
             .withStrukturertAdresse(new Gateadresse()
@@ -32,61 +36,141 @@ public class PersonopplysningerTestConfig {
                     .withHusnummer(2)
                     .withPoststed(new Postnummer().withValue("0560"))
                     .withLandkode(NORGE));
-    private static final PersonIdent PERSON_IDENT = new PersonIdent().withIdent(new NorskIdent().withIdent(FNR));
+    private static final PersonIdent MOR_PERSON_IDENT = new PersonIdent().withIdent(new NorskIdent().withIdent(SøknadTestdata.morPersonident));
+    private static final PersonIdent BARN_PERSON_IDENT = new PersonIdent().withIdent(new NorskIdent().withIdent(SøknadTestdata.barnPersonident));
+    private static final PersonIdent FAR_PERSON_IDENT = new PersonIdent().withIdent(new NorskIdent().withIdent(SøknadTestdata.farPersonident));
 
     @Bean
     @Profile("mock-personopplysninger")
     @Primary
     public PersonConsumer personConsumerMock() throws HentPersonhistorikkSikkerhetsbegrensning, HentPersonhistorikkPersonIkkeFunnet, HentPersonSikkerhetsbegrensning, HentPersonPersonIkkeFunnet {
         PersonConsumer personConsumer = mock(PersonConsumer.class);
-        when(personConsumer.hentPersonhistorikkResponse(any())).thenReturn(hentPersonHistorikkResponse());
-        when(personConsumer.hentPersonResponse(any())).thenReturn(hentPersonResponse());
+        ArgumentCaptor<HentPersonRequest> personRequestCaptor = ArgumentCaptor.forClass(HentPersonRequest.class);
+        ArgumentCaptor<HentPersonhistorikkRequest> historikkRequestCaptor = ArgumentCaptor.forClass(HentPersonhistorikkRequest.class);
+
+        when(personConsumer.hentPersonhistorikkResponse(historikkRequestCaptor.capture())).thenAnswer(invocation -> {
+            PersonIdent personIdent = (PersonIdent) historikkRequestCaptor.getValue().getAktoer();
+            if (personIdent.getIdent().getIdent().equals(SøknadTestdata.barnPersonident)) {
+                return hentPersonhistorikkResponseBarn();
+            } else {
+                return hentPersonHistorikkResponse(personIdent.getIdent().getIdent().equals(SøknadTestdata.morPersonident));
+            }
+        });
+        when(personConsumer.hentPersonResponse(personRequestCaptor.capture())).thenAnswer(invocation -> {
+            PersonIdent personIdent = (PersonIdent) personRequestCaptor.getValue().getAktoer();
+
+            if (personIdent.getIdent().getIdent().equals(SøknadTestdata.morPersonident)) {
+                return hentPersonResponseForMor();
+            } else if (personIdent.getIdent().getIdent().equals(SøknadTestdata.barnPersonident)) {
+                return hentPersonResponseForBarn();
+            } else {
+                return hentPersonResponseForFar();
+            }
+        });
+
         doNothing().when(personConsumer).ping();
         return personConsumer;
     }
 
-    private HentPersonhistorikkResponse hentPersonHistorikkResponse() {
+    private HentPersonhistorikkResponse hentPersonHistorikkResponse(boolean erMor) {
         HentPersonhistorikkResponse response = new HentPersonhistorikkResponse();
-        response.setAktoer(PERSON_IDENT);
+        response.setAktoer(erMor? MOR_PERSON_IDENT : FAR_PERSON_IDENT);
         response
-                .withStatsborgerskapListe(hentStatsborgerskap())
-                .withPersonstatusListe(hentPersonstatus())
+                .withStatsborgerskapListe(hentStatsborgerskap(false))
+                .withPersonstatusListe(hentPersonstatus(false))
                 .withMidlertidigAdressePeriodeListe(hentMidlertidigAdresse())
-                .withBostedsadressePeriodeListe(hentBostedsadresse());
+                .withBostedsadressePeriodeListe(hentBostedsadresse(false));
 
         return response;
     }
 
-    private HentPersonResponse hentPersonResponse() {
-        HentPersonResponse response = new HentPersonResponse();
-        return response.withPerson(hentPerson());
+    private HentPersonhistorikkResponse hentPersonhistorikkResponseBarn() {
+        HentPersonhistorikkResponse response = new HentPersonhistorikkResponse();
+        response.setAktoer(BARN_PERSON_IDENT);
+        response
+                .withStatsborgerskapListe(hentStatsborgerskap(true))
+                .withBostedsadressePeriodeListe(hentBostedsadresse(true))
+                .withPersonstatusListe(hentPersonstatus(true));
+
+        return response;
     }
 
-    private Person hentPerson() {
+    private HentPersonResponse hentPersonResponseForMor() {
+        HentPersonResponse response = new HentPersonResponse();
+        return response.withPerson(hentPersoninfoMor());
+    }
+
+    private HentPersonResponse hentPersonResponseForBarn() {
+        HentPersonResponse response = new HentPersonResponse();
+        return response.withPerson(hentPersoninfoBarn());
+    }
+
+    private HentPersonResponse hentPersonResponseForFar() {
+        HentPersonResponse response = new HentPersonResponse();
+        return response.withPerson(hentPersoninfoFar());
+    }
+
+    private Person hentPersoninfoMor() {
+        Bruker person = new Bruker();
+        person
+                .withBostedsadresse(NORSK_ADRESSE)
+                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("KVINNE")))
+                .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
+                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
+                .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN"))
+                .withHarFraRolleI(hentFamilierelasjonerMor())
+                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
+                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
+                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
+                .withFoedselsdato(hentFoedselsdato("1990-01-01"))
+                .withAktoer(MOR_PERSON_IDENT);
+
+        return person;
+    }
+
+    private Person hentPersoninfoFar() {
         Bruker person = new Bruker();
         person
                 .withBostedsadresse(NORSK_ADRESSE)
                 .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("MANN")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
                 .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
-                .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN"))
-                .withHarFraRolleI(hentFamilierelasjoner())
+                .withPersonnavn(new Personnavn().withSammensattNavn("EKTEMANN TESTESEN"))
+                .withHarFraRolleI(hentFamilierelasjonerFar())
                 .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
                 .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
                 .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
                 .withFoedselsdato(hentFoedselsdato("1990-01-01"))
-                .withAktoer(PERSON_IDENT);
+                .withAktoer(FAR_PERSON_IDENT);
 
         return person;
     }
 
-    private Collection<Familierelasjon> hentFamilierelasjoner() {
+    private Person hentPersoninfoBarn() {
+        Bruker barn = new Bruker();
+        barn
+                .withBostedsadresse(NORSK_ADRESSE)
+                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("KVINNE")))
+                .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("UGIF")))
+                .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
+                .withPersonnavn(new Personnavn().withSammensattNavn("BARN TESTESEN"))
+                .withHarFraRolleI(hentFamilierelasjonerBarn())
+                .withGeografiskTilknytning(new Bydel().withGeografiskTilknytning("0315"))
+                .withGjeldendePostadressetype(new Postadressetyper().withValue("BOSTEDSADRESSE"))
+                .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
+                .withFoedselsdato(hentFoedselsdato("2018-05-01"))
+                .withAktoer(BARN_PERSON_IDENT);
+
+        return barn;
+    }
+
+    private Collection<Familierelasjon> hentFamilierelasjonerMor() {
         Familierelasjon giftMed = new Familierelasjon();
         giftMed
                 .withHarSammeBosted(true)
                 .withTilRolle(new Familierelasjoner().withValue("EKTE"))
                 .withTilPerson(new Person()
-                        .withAktoer(new PersonIdent().withIdent(new NorskIdent().withIdent("12345678901")))
+                        .withAktoer(new PersonIdent().withIdent(new NorskIdent().withIdent(SøknadTestdata.farPersonident)))
                         .withFoedselsdato(hentFoedselsdato("1990-01-01"))
                         .withPersonnavn(new Personnavn().withSammensattNavn("EKTEMANN TESTESEN")));
 
@@ -95,7 +179,51 @@ public class PersonopplysningerTestConfig {
                 .withHarSammeBosted(true)
                 .withTilRolle(new Familierelasjoner().withValue("BARN"))
                 .withTilPerson(new Person()
-                        .withAktoer(new PersonIdent().withIdent(new NorskIdent().withIdent("12345678901")))
+                        .withAktoer(BARN_PERSON_IDENT)
+                        .withFoedselsdato(hentFoedselsdato("2018-05-01"))
+                        .withPersonnavn(new Personnavn().withSammensattNavn("BARN TESTESEN")));
+
+        return Arrays.asList(giftMed, barnet);
+    }
+
+    private Collection<Familierelasjon> hentFamilierelasjonerBarn() {
+        Familierelasjon far = new Familierelasjon();
+        far
+                .withHarSammeBosted(true)
+                .withTilRolle(new Familierelasjoner().withValue("FARA"))
+                .withTilPerson(new Person()
+                        .withAktoer(new PersonIdent().withIdent(new NorskIdent().withIdent(SøknadTestdata.farPersonident)))
+                        .withFoedselsdato(hentFoedselsdato("1990-01-01"))
+                        .withPersonnavn(new Personnavn().withSammensattNavn("EKTEMANN TESTESEN")));
+
+        Familierelasjon mor = new Familierelasjon();
+        mor
+                .withHarSammeBosted(true)
+                .withTilRolle(new Familierelasjoner().withValue("MORA"))
+                .withTilPerson(new Person()
+                        .withAktoer(MOR_PERSON_IDENT)
+                        .withFoedselsdato(hentFoedselsdato("1990-01-01"))
+                        .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN")));
+
+        return Arrays.asList(far, mor);
+    }
+
+    private Collection<Familierelasjon> hentFamilierelasjonerFar() {
+        Familierelasjon giftMed = new Familierelasjon();
+        giftMed
+                .withHarSammeBosted(true)
+                .withTilRolle(new Familierelasjoner().withValue("EKTE"))
+                .withTilPerson(new Person()
+                        .withAktoer(MOR_PERSON_IDENT)
+                        .withFoedselsdato(hentFoedselsdato("1990-01-01"))
+                        .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN")));
+
+        Familierelasjon barnet = new Familierelasjon();
+        barnet
+                .withHarSammeBosted(true)
+                .withTilRolle(new Familierelasjoner().withValue("BARN"))
+                .withTilPerson(new Person()
+                        .withAktoer(BARN_PERSON_IDENT)
                         .withFoedselsdato(hentFoedselsdato("2018-05-01"))
                         .withPersonnavn(new Personnavn().withSammensattNavn("BARN TESTESEN")));
 
@@ -110,35 +238,35 @@ public class PersonopplysningerTestConfig {
         }
     }
 
-    private Collection<PersonstatusPeriode> hentPersonstatus() {
+    private Collection<PersonstatusPeriode> hentPersonstatus(boolean erBarnet) {
         PersonstatusPeriode personstatusPeriode = new PersonstatusPeriode();
         personstatusPeriode
                 .withPersonstatus(new Personstatuser().withValue("BOSA"))
                 .withPeriode(new Periode()
-                        .withFom(DateUtil.convertToXMLGregorianCalendar(FOM))
+                        .withFom(DateUtil.convertToXMLGregorianCalendar(erBarnet ? FOM_BARNET : FOM))
                         .withTom(DateUtil.convertToXMLGregorianCalendar(TOM)));
 
         return Collections.singletonList(personstatusPeriode);
 
     }
 
-    private Collection<StatsborgerskapPeriode> hentStatsborgerskap() {
+    private Collection<StatsborgerskapPeriode> hentStatsborgerskap(boolean erBarnet) {
         StatsborgerskapPeriode statsborgerskapPeriode = new StatsborgerskapPeriode();
         statsborgerskapPeriode
                 .withStatsborgerskap(new Statsborgerskap().withLand(NORGE))
                 .withPeriode(new Periode()
-                        .withFom(DateUtil.convertToXMLGregorianCalendar(FOM))
+                        .withFom(DateUtil.convertToXMLGregorianCalendar(erBarnet ? FOM_BARNET : FOM))
                         .withTom(DateUtil.convertToXMLGregorianCalendar(TOM)));
 
         return Collections.singletonList(statsborgerskapPeriode);
     }
 
-    private Collection<BostedsadressePeriode> hentBostedsadresse() {
+    private Collection<BostedsadressePeriode> hentBostedsadresse(boolean erBarnet) {
         BostedsadressePeriode bostedsadressePeriode = new BostedsadressePeriode();
         bostedsadressePeriode
                 .withBostedsadresse(NORSK_ADRESSE)
                 .withPeriode(new Periode()
-                        .withFom(DateUtil.convertToXMLGregorianCalendar(FOM))
+                        .withFom(DateUtil.convertToXMLGregorianCalendar(erBarnet ? FOM_BARNET : FOM))
                         .withTom(DateUtil.convertToXMLGregorianCalendar(TOM)));
 
         return Collections.singletonList(bostedsadressePeriode);

--- a/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
@@ -49,6 +49,10 @@ public class PersonopplysningerTestConfig {
         ArgumentCaptor<HentPersonhistorikkRequest> historikkRequestCaptor = ArgumentCaptor.forClass(HentPersonhistorikkRequest.class);
 
         when(personConsumer.hentPersonhistorikkResponse(historikkRequestCaptor.capture())).thenAnswer(invocation -> {
+            if (historikkRequestCaptor.getValue() == null) {
+                return null;
+            }
+
             PersonIdent personIdent = (PersonIdent) historikkRequestCaptor.getValue().getAktoer();
             if (SøknadTestdata.barnPersonident.equals(personIdent.getIdent().getIdent())) {
                 return hentPersonhistorikkResponseBarn();
@@ -58,6 +62,10 @@ public class PersonopplysningerTestConfig {
         });
 
         when(personConsumer.hentPersonResponse(personRequestCaptor.capture())).thenAnswer(invocation -> {
+            if (personRequestCaptor.getValue() == null) {
+                return null;
+            }
+
             PersonIdent personIdent = (PersonIdent) personRequestCaptor.getValue().getAktoer();
 
             if (SøknadTestdata.morPersonident.equals(personIdent.getIdent().getIdent())) {

--- a/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
+++ b/src/test/java/no/nav/familie/ks/oppslag/personopplysning/PersonopplysningerTestConfig.java
@@ -114,7 +114,7 @@ public class PersonopplysningerTestConfig {
         Bruker person = new Bruker();
         person
                 .withBostedsadresse(NORSK_ADRESSE)
-                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("KVINNE")))
+                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("K")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
                 .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("TEST TESTESEN"))
@@ -132,7 +132,7 @@ public class PersonopplysningerTestConfig {
         Bruker person = new Bruker();
         person
                 .withBostedsadresse(NORSK_ADRESSE)
-                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("MANN")))
+                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("M")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("GIFT")))
                 .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("EKTEMANN TESTESEN"))
@@ -150,7 +150,7 @@ public class PersonopplysningerTestConfig {
         Bruker barn = new Bruker();
         barn
                 .withBostedsadresse(NORSK_ADRESSE)
-                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withKodeRef("KVINNE")))
+                .withKjoenn(new Kjoenn().withKjoenn(new Kjoennstyper().withValue("K")))
                 .withSivilstand(new Sivilstand().withSivilstand(new Sivilstander().withValue("UGIF")))
                 .withPersonstatus(new Personstatus().withPersonstatus(new Personstatuser().withValue("BOSA")))
                 .withPersonnavn(new Personnavn().withSammensattNavn("BARN TESTESEN"))


### PR DESCRIPTION
Tilpasset mockdata basert på personidenter fra kontrakten. Begrenset tps-mock til mor, far og barn da det blir litt mye å lage for 6 ulike personer. 